### PR TITLE
Aoharu is out, Unity is in

### DIFF
--- a/src/global/components/SelectedCards.js
+++ b/src/global/components/SelectedCards.js
@@ -97,7 +97,7 @@ function SelectedCards(props) {
             </div>
             {cards}
             <div>
-                Total Race Bonus: <b>{raceBonus}</b> <i>(aim for 35 for URA/Aoharu, 50 for MANT)</i>
+                Total Race Bonus: <b>{raceBonus}</b> <i>(aim for 35 for URA/Unity, 50 for MANT)</i>
             </div>
             <div className="link">
                 <a href={getEventHelperURL(props.selectedCards)} target="_blank">Open in Gametora Event Helper</a>

--- a/src/global/components/Weights.js
+++ b/src/global/components/Weights.js
@@ -633,7 +633,7 @@ class Weights extends React.Component {
                         <button id="reset-weights-GL" type="button" onClick={this.onGMReset}>GM</button>
                         <button id="reset-weights-GL" type="button" onClick={this.onGLReset}>GL</button>
                         <button id="reset-weights-MANT" type="button" onClick={this.onMANTReset}>MANT</button>
-                        <button id="reset-weights-URA" type="button" onClick={this.onAoharuReset}>Aoharu</button>
+                        <button id="reset-weights-URA" type="button" onClick={this.onAoharuReset}>Unity</button>
                         <button id="reset-weights-URA" type="button" onClick={this.onURAReset}>URA</button>
                     </div>
                     <div className="weight-row">


### PR DESCRIPTION
The new scenario is called Unity Cup in the global version, so Global should probably not refer to it as Aoharu. Therefore the two times `Aoharu` appears in text on the global version of the website, they have been replaced with `Unity`.